### PR TITLE
Add volant-compose CLI tool for Docker Compose migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,39 @@ build/kestrel
 build/volant-initramfs.cpio.gz
 .DS_STORE
 bin
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+dev-debug.log
+# Dependency directories
+node_modules/
+# Environment variables
+.env
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+# OS specific
+.DS_Store
+
+# Task files
+# tasks.json
+# tasks/
+
+# Development and internal files
+.taskmaster/
+.cursor/
+.mcp.json
+CLAUDE.md
+VOLANT_MANIFESTO.md
+TRACK_F_SUMMARY.md
+test-volant-compose.sh
+.gitignore_pr 

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,11 @@ build-cli: ## Build the volar CLI binary
 	mkdir -p $(BIN_DIR)
 	$(GO) build -o $(BIN_DIR)/volar ./cmd/volar
 
+.PHONY: build-compose
+build-compose: ## Build the volant-compose CLI binary
+	mkdir -p $(BIN_DIR)
+	$(GO) build -o $(BIN_DIR)/volant-compose ./cmd/volant-compose
+
 .PHONY: build-drift
 ifeq ($(UNAME_S),Linux)
 build-drift: build-drift-bpf

--- a/cmd/volant-compose/README.md
+++ b/cmd/volant-compose/README.md
@@ -1,0 +1,96 @@
+# volant-compose
+
+Convert Docker Compose files to Volant stack definitions.
+
+## Quick Start
+
+```bash
+# Convert docker-compose.yml to volant.yaml
+volant-compose convert -f docker-compose.yml -o volant.yaml
+
+# Validate before converting
+volant-compose validate -f docker-compose.yml
+
+# Get help
+volant-compose --help
+```
+
+## Installation
+
+```bash
+# Build from source
+make build-compose
+
+# Binary will be in bin/volant-compose
+./bin/volant-compose --version
+```
+
+## What is volant-compose?
+
+`volant-compose` bridges the gap between Docker Compose and Volant, converting container-centric configurations to VM-centric stack definitions. It handles the architectural differences between Docker's shared-kernel model and Volant's isolated microVM approach.
+
+## Features
+
+✅ **Supported:**
+- Services (image, ports, environment, volumes, depends_on)
+- Named volumes
+- Port mappings
+- Environment variables (array and map formats)
+- Command and entrypoint overrides
+
+❌ **Not Supported:**
+- Build contexts (use Fledge)
+- Bind mounts (use named volumes)
+- deploy.replicas (Phase 2)
+- Multiple custom networks (simplified to single subnet)
+
+## Documentation
+
+See [docs/volant-compose.md](../../docs/volant-compose.md) for complete documentation including:
+- Installation guide
+- Usage examples
+- Migration guide
+- Troubleshooting
+- API reference
+
+## Examples
+
+### WordPress + MySQL
+
+```bash
+cd testdata/wordpress
+volant-compose convert -f docker-compose.yml -o volant.yaml
+```
+
+### Node.js + MongoDB
+
+```bash
+cd testdata/nodejs-mongo
+volant-compose convert -f docker-compose.yml -o volant.yaml
+```
+
+## Architecture
+
+volant-compose consists of three main packages:
+
+- **pkg/compose**: Docker Compose YAML parser
+- **pkg/volant**: Volant stack YAML schema
+- **pkg/converter**: Impedance mismatch handler
+
+See the [Docker Compose Migration Guide](../../docs/3_guides/6_docker-compose-migration.md) for detailed conversion rules and examples.
+
+## Testing
+
+```bash
+# Unit tests
+go test ./pkg/compose/...
+go test ./pkg/volant/...
+go test ./pkg/converter/...
+
+# Integration tests
+go test github.com/volantvm/volant/pkg/converter -run Integration
+```
+
+## License
+
+Same as Volant project.

--- a/cmd/volant-compose/main.go
+++ b/cmd/volant-compose/main.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/volantvm/volant/pkg/compose"
+	"github.com/volantvm/volant/pkg/converter"
+	"github.com/volantvm/volant/pkg/volant"
+)
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "volant-compose",
+	Short: "Convert Docker Compose files to Volant stacks",
+	Long: `volant-compose is a CLI tool that converts docker-compose.yml files
+to volant.yaml stack definitions for the Volant microVM orchestrator.
+
+Volant provides VM-level security isolation with container-like speed,
+and this tool helps you migrate from Docker Compose to Volant seamlessly.`,
+	Version: fmt.Sprintf("%s (commit: %s, built: %s)", version, commit, date),
+}
+
+var convertCmd = &cobra.Command{
+	Use:   "convert",
+	Short: "Convert docker-compose.yml to volant.yaml",
+	Long: `Convert a Docker Compose file to a Volant stack definition.
+
+This command parses your docker-compose.yml file and generates a
+volant.yaml file that can be deployed to the Volant orchestrator.
+
+Supported features:
+  - Services (image, ports, environment, volumes)
+  - Named volumes
+  - Service dependencies (depends_on)
+  - Environment variables (map and array syntax)
+  - Port mappings
+
+Unsupported features (will error):
+  - Build contexts (use Fledge separately)
+  - Bind mounts (use named volumes)
+  - deploy.replicas (Phase 2)
+  - Health checks (Track D)
+  - Secrets (Track A)
+
+Example:
+  volant-compose convert -f docker-compose.yml -o volant.yaml
+  volant-compose convert --name my-stack
+`,
+	RunE: runConvert,
+}
+
+var validateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate docker-compose.yml can be converted",
+	Long: `Validate that a Docker Compose file can be successfully converted
+to a Volant stack definition without actually writing the output file.
+
+This is useful for checking if your docker-compose.yml file uses
+any unsupported features before attempting conversion.
+
+Example:
+  volant-compose validate -f docker-compose.yml
+`,
+	RunE: runValidate,
+}
+
+var (
+	inputFile  string
+	outputFile string
+	stackName  string
+	verbose    bool
+)
+
+func init() {
+	// Add commands
+	rootCmd.AddCommand(convertCmd)
+	rootCmd.AddCommand(validateCmd)
+
+	// Convert command flags
+	convertCmd.Flags().StringVarP(&inputFile, "file", "f", "docker-compose.yml", "Input docker-compose.yml file")
+	convertCmd.Flags().StringVarP(&outputFile, "output", "o", "volant.yaml", "Output volant.yaml file")
+	convertCmd.Flags().StringVarP(&stackName, "name", "n", "", "Stack name (default: derived from directory)")
+	convertCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
+
+	// Validate command flags
+	validateCmd.Flags().StringVarP(&inputFile, "file", "f", "docker-compose.yml", "Input docker-compose.yml file")
+	validateCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
+}
+
+func runConvert(cmd *cobra.Command, args []string) error {
+	if verbose {
+		fmt.Printf("Reading %s...\n", inputFile)
+	}
+
+	// Parse Docker Compose file
+	composeFile, err := compose.Parse(inputFile)
+	if err != nil {
+		return fmt.Errorf("failed to parse docker-compose.yml: %w", err)
+	}
+
+	if verbose {
+		fmt.Printf("Parsed %d services\n", len(composeFile.Services))
+	}
+
+	// Derive stack name if not provided
+	name := stackName
+	if name == "" {
+		name = converter.DeriveStackName(inputFile)
+		if verbose {
+			fmt.Printf("Derived stack name: %s\n", name)
+		}
+	}
+
+	// Convert to Volant format
+	if verbose {
+		fmt.Println("Converting to Volant stack...")
+	}
+
+	stack, err := converter.Convert(composeFile, name)
+	if err != nil {
+		return fmt.Errorf("conversion failed: %w", err)
+	}
+
+	// Write Volant YAML
+	if verbose {
+		fmt.Printf("Writing %s...\n", outputFile)
+	}
+
+	if err := volant.WriteYAML(stack, outputFile); err != nil {
+		return fmt.Errorf("failed to write volant.yaml: %w", err)
+	}
+
+	fmt.Printf("✅ Successfully converted %s → %s\n", inputFile, outputFile)
+	fmt.Printf("   Stack name: %s\n", stack.Name)
+	fmt.Printf("   Services: %d\n", len(stack.Services))
+	if len(stack.Volumes) > 0 {
+		fmt.Printf("   Volumes: %d\n", len(stack.Volumes))
+	}
+
+	fmt.Println("\nNext steps:")
+	fmt.Println("  1. Review the generated volant.yaml file")
+	fmt.Println("  2. Build any required images with Fledge:")
+	fmt.Println("     fledge build -f Dockerfile --name myapp --version 1.0.0")
+	fmt.Println("  3. Deploy the stack (Phase 2):")
+	fmt.Println("     volant stack deploy -f volant.yaml")
+
+	return nil
+}
+
+func runValidate(cmd *cobra.Command, args []string) error {
+	if verbose {
+		fmt.Printf("Reading %s...\n", inputFile)
+	}
+
+	// Parse Docker Compose file
+	composeFile, err := compose.Parse(inputFile)
+	if err != nil {
+		return fmt.Errorf("failed to parse docker-compose.yml: %w", err)
+	}
+
+	if verbose {
+		fmt.Printf("Parsed %d services\n", len(composeFile.Services))
+	}
+
+	// Try to convert (but don't write)
+	if verbose {
+		fmt.Println("Validating conversion...")
+	}
+
+	name := stackName
+	if name == "" {
+		name = converter.DeriveStackName(inputFile)
+	}
+
+	_, err = converter.Convert(composeFile, name)
+	if err != nil {
+		fmt.Println("❌ Validation failed:")
+		fmt.Printf("   %v\n", err)
+		return err
+	}
+
+	fmt.Println("✅ Validation successful!")
+	fmt.Printf("   File: %s\n", inputFile)
+	fmt.Printf("   Services: %d\n", len(composeFile.Services))
+	if len(composeFile.Volumes) > 0 {
+		fmt.Printf("   Volumes: %d\n", len(composeFile.Volumes))
+	}
+	fmt.Println("\nThis docker-compose.yml file can be converted to Volant format.")
+	fmt.Println("Run 'volant-compose convert' to generate volant.yaml")
+
+	return nil
+}

--- a/docs/3_guides/6_docker-compose-migration.md
+++ b/docs/3_guides/6_docker-compose-migration.md
@@ -1,0 +1,542 @@
+# Docker Compose Migration Guide
+
+## Overview
+
+`volant-compose` is a CLI tool that converts Docker Compose files (`docker-compose.yml`) to Volant stack definitions (`volant.yaml`). It bridges the gap between Docker's container-centric model and Volant's VM-centric architecture, enabling migration from Docker Compose to Volant's microVM orchestration platform.
+
+## Why volant-compose?
+
+Docker Compose is widely used but has security limitations due to shared kernel architecture. Volant provides VM-level isolation with container-like speed (200-500ms boot times), but requires a different configuration format. This tool automates the conversion process while handling the architectural differences between containers and microVMs.
+
+## Installation
+
+### From Source
+
+```bash
+# Clone the repository
+git clone https://github.com/volantvm/volant.git
+cd volant
+
+# Build volant-compose
+make build-compose
+
+# The binary will be in bin/volant-compose
+./bin/volant-compose --version
+```
+
+### Manual Build
+
+```bash
+go build -o volant-compose ./cmd/volant-compose
+```
+
+## Quick Start
+
+### Basic Conversion
+
+```bash
+# Convert docker-compose.yml to volant.yaml
+volant-compose convert -f docker-compose.yml -o volant.yaml
+
+# With custom stack name
+volant-compose convert -f docker-compose.yml -o volant.yaml --name my-stack
+
+# Verbose output
+volant-compose convert -f docker-compose.yml -v
+```
+
+### Validation
+
+Check if your docker-compose.yml can be converted before actually converting:
+
+```bash
+volant-compose validate -f docker-compose.yml
+```
+
+## Supported Features
+
+| Feature | Docker Compose | Volant | Status |
+|---------|---------------|---------|--------|
+| **Services** | container-centric | VM-centric | ✅ Supported |
+| **Image** | `image: nginx:latest` | `image: nginx:latest` | ✅ Direct mapping |
+| **Ports** | `"8080:80"` | `"8080:80"` | ✅ Direct mapping |
+| **Environment** | Array or map | Map | ✅ Converted |
+| **Volumes** | Named volumes | Named volumes | ✅ Supported |
+| **Dependencies** | `depends_on` | `depends_on` | ✅ Direct mapping |
+| **Command** | `command` | `args` | ✅ Converted |
+| **Entrypoint** | `entrypoint` | `entrypoint` | ✅ Direct mapping |
+| **Networks** | Custom networks | Single subnet | ⚠️ Simplified |
+
+## Unsupported Features
+
+The following Docker Compose features are **not supported** and will cause conversion errors:
+
+### Build Contexts
+```yaml
+# ❌ NOT SUPPORTED
+services:
+  app:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+```
+
+**Solution:** Use Fledge to build images separately:
+```bash
+fledge build -f app/Dockerfile --name myapp --version 1.0.0
+volant image import myapp:1.0.0
+```
+
+### Bind Mounts
+```yaml
+# ❌ NOT SUPPORTED
+services:
+  web:
+    volumes:
+      - ./html:/usr/share/nginx/html
+```
+
+**Solution:** Use named volumes:
+```yaml
+# ✅ SUPPORTED
+services:
+  web:
+    volumes:
+      - html-data:/usr/share/nginx/html
+
+volumes:
+  html-data:
+```
+
+### Replicas
+```yaml
+# ❌ NOT SUPPORTED (Phase 2)
+services:
+  api:
+    deploy:
+      replicas: 3
+```
+
+**Solution:** Phase 2 feature (horizontal scaling)
+
+### Other Unsupported Features
+- Health checks (Track D - Stack Orchestrator)
+- Secrets (Track A - Environment Variables)
+- Configs
+- Docker Swarm deployment settings
+- Resource limits (memory/cpu limits in deploy section)
+
+## Docker Compose → Volant Mapping
+
+### Container Name → VM Name
+```yaml
+# Docker Compose
+services:
+  web:
+    container_name: my-web
+
+# Volant (service name becomes VM identifier)
+services:
+  web:
+    image: nginx:latest
+```
+
+### Environment Variables
+```yaml
+# Docker Compose (array format)
+services:
+  app:
+    environment:
+      - DATABASE_URL=postgres://localhost/db
+      - API_KEY=secret
+
+# Volant (map format)
+services:
+  app:
+    environment:
+      DATABASE_URL: postgres://localhost/db
+      API_KEY: secret
+```
+
+### Service Discovery
+```yaml
+# Docker Compose
+services:
+  web:
+    environment:
+      DATABASE_URL: postgres://db:5432/mydb
+
+# Volant (use .svc.volant DNS suffix)
+services:
+  web:
+    environment:
+      DATABASE_URL: postgres://db.svc.volant:5432/mydb
+```
+
+### Memory and CPU
+```yaml
+# Volant adds VM resource allocations
+services:
+  web:
+    image: nginx:latest
+    memory: 512  # MB (default: 512)
+    vcpus: 1     # CPU count (default: 1)
+```
+
+## Examples
+
+### Example 1: WordPress + MySQL
+
+**Input: docker-compose.yml**
+```yaml
+version: "3.8"
+
+services:
+  wordpress:
+    image: wordpress:latest
+    ports:
+      - "8080:80"
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: secret
+    depends_on:
+      - db
+    volumes:
+      - wordpress-data:/var/www/html
+
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: secret
+      MYSQL_ROOT_PASSWORD: rootsecret
+    volumes:
+      - db-data:/var/lib/mysql
+
+volumes:
+  wordpress-data:
+  db-data:
+```
+
+**Output: volant.yaml**
+```yaml
+version: "1.0"
+name: wordpress-stack
+services:
+  wordpress:
+    image: wordpress:latest
+    memory: 512
+    vcpus: 1
+    ports:
+      - 8080:80
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: secret
+    volumes:
+      - wordpress-data:/var/www/html
+    depends_on:
+      - db
+  db:
+    image: mysql:8.0
+    memory: 512
+    vcpus: 1
+    environment:
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: secret
+      MYSQL_ROOT_PASSWORD: rootsecret
+    volumes:
+      - db-data:/var/lib/mysql
+networks:
+  default:
+    subnet: 192.168.127.0/24
+    gateway: 192.168.127.1
+volumes:
+  wordpress-data:
+    size: 10G
+  db-data:
+    size: 10G
+```
+
+### Example 2: Node.js + MongoDB
+
+**Input: docker-compose.yml**
+```yaml
+version: "3.8"
+
+services:
+  app:
+    image: node:18-alpine
+    ports:
+      - "3000:3000"
+    environment:
+      NODE_ENV: production
+      MONGO_URL: mongodb://mongo:27017/myapp
+    depends_on:
+      - mongo
+    command: ["node", "server.js"]
+
+  mongo:
+    image: mongo:7
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=admin
+      - MONGO_INITDB_ROOT_PASSWORD=secret
+    volumes:
+      - mongo-data:/data/db
+
+volumes:
+  mongo-data:
+```
+
+**Conversion:**
+```bash
+volant-compose convert -f docker-compose.yml -o volant.yaml --name nodejs-stack
+```
+
+## Migration Guide
+
+### Step 1: Audit Your docker-compose.yml
+
+Check for unsupported features:
+```bash
+volant-compose validate -f docker-compose.yml
+```
+
+If you see errors:
+- Remove `build:` directives (use Fledge separately)
+- Replace bind mounts with named volumes
+- Remove `deploy.replicas` settings
+
+### Step 2: Build Images with Fledge
+
+If your docker-compose.yml uses `build:` directives, build images with Fledge first:
+
+```bash
+# For each service with build: directive
+cd service-directory
+fledge build -f Dockerfile --name service-name --version 1.0.0
+
+# Import to Volant
+volant image import service-name:1.0.0
+```
+
+### Step 3: Convert Compose File
+
+```bash
+volant-compose convert -f docker-compose.yml -o volant.yaml --name my-stack
+```
+
+### Step 4: Review Generated volant.yaml
+
+Check:
+- ✅ Service names are correct
+- ✅ Environment variables are preserved
+- ✅ Volumes are named volumes (not bind mounts)
+- ✅ Dependencies are correct
+- ✅ Port mappings are correct
+
+### Step 5: Deploy (Phase 2)
+
+```bash
+# Once Phase 2 (Track D - Stack Orchestrator) is complete:
+volant stack deploy -f volant.yaml
+```
+
+## Troubleshooting
+
+### Error: 'build' directive not supported
+
+**Problem:**
+```
+service 'app': 'build' directive not supported
+   → Use Fledge to build images: fledge build -f Dockerfile
+```
+
+**Solution:**
+1. Build the image with Fledge:
+   ```bash
+   fledge build -f app/Dockerfile --name myapp --version 1.0.0
+   ```
+2. Update docker-compose.yml to use the built image:
+   ```yaml
+   services:
+     app:
+       image: myapp:1.0.0  # Remove build: directive
+   ```
+3. Convert again
+
+### Error: bind mount not supported
+
+**Problem:**
+```
+service 'web': bind mount './html:/data' not supported
+   → Use named volumes instead: volumes: [data:/data]
+```
+
+**Solution:**
+Replace bind mount with named volume:
+```yaml
+# Before
+services:
+  web:
+    volumes:
+      - ./html:/usr/share/nginx/html
+
+# After
+services:
+  web:
+    volumes:
+      - html-data:/usr/share/nginx/html
+
+volumes:
+  html-data:
+```
+
+### Error: deploy.replicas not supported
+
+**Problem:**
+```
+service 'api': deploy.replicas=3 not supported yet
+   → Phase 2 feature (horizontal scaling)
+```
+
+**Solution:**
+Remove replicas for now. This will be supported in Phase 2.
+
+## CLI Reference
+
+### Global Flags
+
+```
+-h, --help      Show help
+-v, --version   Show version
+```
+
+### convert Command
+
+Convert a docker-compose.yml file to volant.yaml
+
+**Usage:**
+```bash
+volant-compose convert [flags]
+```
+
+**Flags:**
+```
+-f, --file string      Input docker-compose.yml file (default: docker-compose.yml)
+-o, --output string    Output volant.yaml file (default: volant.yaml)
+-n, --name string      Stack name (default: derived from directory name)
+-v, --verbose          Verbose output
+-h, --help            Help for convert
+```
+
+**Examples:**
+```bash
+# Basic conversion
+volant-compose convert
+
+# Custom files
+volant-compose convert -f compose.yml -o stack.yaml
+
+# Custom stack name
+volant-compose convert --name production-stack
+
+# Verbose output
+volant-compose convert -v
+```
+
+### validate Command
+
+Validate that a docker-compose.yml file can be converted
+
+**Usage:**
+```bash
+volant-compose validate [flags]
+```
+
+**Flags:**
+```
+-f, --file string   Input docker-compose.yml file (default: docker-compose.yml)
+-v, --verbose       Verbose output
+-h, --help         Help for validate
+```
+
+**Examples:**
+```bash
+# Validate default file
+volant-compose validate
+
+# Validate specific file
+volant-compose validate -f my-compose.yml
+
+# Verbose validation
+volant-compose validate -v
+```
+
+## Architecture Notes
+
+### Impedance Mismatches
+
+Docker Compose and Volant have different architectural philosophies:
+
+| Aspect | Docker Compose | Volant |
+|--------|---------------|---------|
+| **Isolation** | Container (shared kernel) | MicroVM (isolated kernel) |
+| **Boot Time** | <1s | 200-500ms |
+| **Resource Model** | Soft limits | Hard allocation |
+| **Networking** | Bridge + custom networks | Static IP pool (192.168.127.0/24) |
+| **Service Discovery** | Docker DNS | DNS (.svc.volant) |
+
+### Design Decisions
+
+1. **Named Volumes Only:** Bind mounts require host filesystem access, which violates VM isolation principles.
+
+2. **Single Subnet:** Volant Phase 1 uses a single subnet (192.168.127.0/24). Custom networks are simplified.
+
+3. **Static Memory/CPU:** Each service gets VM resource allocations (default: 512MB, 1 vCPU).
+
+4. **No Build Support:** Image building is delegated to Fledge to maintain separation of concerns.
+
+## FAQ
+
+**Q: Can I use my existing docker-compose.yml without changes?**
+
+A: Most docker-compose.yml files work with minimal changes. The main issues are build contexts and bind mounts, which need to be addressed.
+
+**Q: What happens to my custom networks?**
+
+A: Volant Phase 1 uses a single default subnet (192.168.127.0/24). Custom network definitions are ignored but services can still communicate.
+
+**Q: How do I set memory and CPU for services?**
+
+A: The converter applies defaults (512MB, 1 vCPU). You can manually edit the generated volant.yaml to adjust these values.
+
+**Q: Can I convert back from volant.yaml to docker-compose.yml?**
+
+A: Not currently. The conversion is one-way due to VM-specific features in Volant.
+
+**Q: What about Docker Compose v2 or v1?**
+
+A: Only v3.x is supported. If you have v1 or v2, upgrade to v3 first using `docker-compose config`.
+
+## Contributing
+
+Contributions are welcome! See the main Volant repository for contribution guidelines.
+
+## License
+
+Same as Volant project.
+
+## Support
+
+- GitHub Issues: https://github.com/volantvm/volant/issues
+- Documentation: https://github.com/volantvm/volant/tree/main/docs
+
+## Related Documentation
+
+- [Getting Started Guide](../2_getting-started/1_installation.md) - Installation and setup
+- [Networking Guide](./1_networking.md) - Network configuration
+- [Troubleshooting](./5_troubleshooting.md) - Common issues and solutions

--- a/pkg/compose/parser.go
+++ b/pkg/compose/parser.go
@@ -1,0 +1,239 @@
+package compose
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ComposeFile represents a docker-compose.yml file structure
+type ComposeFile struct {
+	Version  string                `yaml:"version"`
+	Services map[string]Service    `yaml:"services"`
+	Networks map[string]Network    `yaml:"networks,omitempty"`
+	Volumes  map[string]Volume     `yaml:"volumes,omitempty"`
+}
+
+// Service represents a service definition in docker-compose
+type Service struct {
+	Image       string                 `yaml:"image,omitempty"`
+	Build       *BuildConfig           `yaml:"build,omitempty"`
+	ContainerName string               `yaml:"container_name,omitempty"`
+	Ports       []string               `yaml:"ports,omitempty"`
+	Environment interface{}            `yaml:"environment,omitempty"` // Can be array or map
+	Volumes     []string               `yaml:"volumes,omitempty"`
+	DependsOn   interface{}            `yaml:"depends_on,omitempty"` // Can be array or map
+	Networks    interface{}            `yaml:"networks,omitempty"`   // Can be array or map
+	Command     interface{}            `yaml:"command,omitempty"`    // Can be string or array
+	Entrypoint  interface{}            `yaml:"entrypoint,omitempty"` // Can be string or array
+	Deploy      *DeployConfig          `yaml:"deploy,omitempty"`
+	Labels      interface{}            `yaml:"labels,omitempty"`
+	Restart     string                 `yaml:"restart,omitempty"`
+	HealthCheck *HealthCheck           `yaml:"healthcheck,omitempty"`
+	Extra       map[string]interface{} `yaml:",inline"` // Capture any other fields
+}
+
+// BuildConfig represents build configuration
+type BuildConfig struct {
+	Context    string            `yaml:"context,omitempty"`
+	Dockerfile string            `yaml:"dockerfile,omitempty"`
+	Args       map[string]string `yaml:"args,omitempty"`
+}
+
+// DeployConfig represents deploy configuration (Docker Swarm)
+type DeployConfig struct {
+	Replicas int                    `yaml:"replicas,omitempty"`
+	Extra    map[string]interface{} `yaml:",inline"`
+}
+
+// HealthCheck represents health check configuration
+type HealthCheck struct {
+	Test     []string `yaml:"test,omitempty"`
+	Interval string   `yaml:"interval,omitempty"`
+	Timeout  string   `yaml:"timeout,omitempty"`
+	Retries  int      `yaml:"retries,omitempty"`
+}
+
+// Network represents a network definition
+type Network struct {
+	Driver string                 `yaml:"driver,omitempty"`
+	Extra  map[string]interface{} `yaml:",inline"`
+}
+
+// Volume represents a volume definition
+type Volume struct {
+	Driver string                 `yaml:"driver,omitempty"`
+	Extra  map[string]interface{} `yaml:",inline"`
+}
+
+// Parse reads and parses a docker-compose.yml file
+func Parse(path string) (*ComposeFile, error) {
+	// Read the file
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %s: %w", path, err)
+	}
+
+	// Parse YAML
+	var compose ComposeFile
+	if err := yaml.Unmarshal(data, &compose); err != nil {
+		return nil, fmt.Errorf("failed to parse YAML: %w", err)
+	}
+
+	// Validate
+	if err := compose.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &compose, nil
+}
+
+// Validate checks if the compose file is valid
+func (c *ComposeFile) Validate() error {
+	// Check version
+	if c.Version == "" {
+		return fmt.Errorf("version field is required")
+	}
+
+	// Validate version format (should be 3.x)
+	if !strings.HasPrefix(c.Version, "3.") && c.Version != "3" {
+		return fmt.Errorf("unsupported version: %s (only version 3.x is supported)", c.Version)
+	}
+
+	// Check services
+	if len(c.Services) == 0 {
+		return fmt.Errorf("at least one service is required")
+	}
+
+	// Validate each service
+	for name, service := range c.Services {
+		if err := service.Validate(name); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Validate checks if a service is valid
+func (s *Service) Validate(name string) error {
+	// Either image or build must be specified
+	if s.Image == "" && s.Build == nil {
+		return fmt.Errorf("service '%s': either 'image' or 'build' must be specified", name)
+	}
+
+	// If both are specified, that's ok (build takes precedence)
+
+	return nil
+}
+
+// GetEnvironmentMap converts environment to a map (from array or map format)
+func (s *Service) GetEnvironmentMap() map[string]string {
+	env := make(map[string]string)
+
+	if s.Environment == nil {
+		return env
+	}
+
+	switch e := s.Environment.(type) {
+	case []interface{}:
+		// Array format: ["FOO=bar", "BAZ=qux"]
+		for _, item := range e {
+			if str, ok := item.(string); ok {
+				parts := strings.SplitN(str, "=", 2)
+				if len(parts) == 2 {
+					env[parts[0]] = parts[1]
+				} else {
+					env[parts[0]] = ""
+				}
+			}
+		}
+	case map[string]interface{}:
+		// Map format: {FOO: bar, BAZ: qux}
+		for k, v := range e {
+			if v == nil {
+				env[k] = ""
+			} else {
+				env[k] = fmt.Sprintf("%v", v)
+			}
+		}
+	}
+
+	return env
+}
+
+// GetDependsOnList converts depends_on to a string slice
+func (s *Service) GetDependsOnList() []string {
+	var deps []string
+
+	if s.DependsOn == nil {
+		return deps
+	}
+
+	switch d := s.DependsOn.(type) {
+	case []interface{}:
+		// Array format: ["db", "cache"]
+		for _, item := range d {
+			if str, ok := item.(string); ok {
+				deps = append(deps, str)
+			}
+		}
+	case map[string]interface{}:
+		// Map format (v3.x): {db: {condition: service_started}}
+		for k := range d {
+			deps = append(deps, k)
+		}
+	}
+
+	return deps
+}
+
+// GetCommandSlice converts command to a string slice
+func (s *Service) GetCommandSlice() []string {
+	if s.Command == nil {
+		return nil
+	}
+
+	switch c := s.Command.(type) {
+	case string:
+		// String format: "npm start"
+		return []string{"/bin/sh", "-c", c}
+	case []interface{}:
+		// Array format: ["npm", "start"]
+		var cmd []string
+		for _, item := range c {
+			if str, ok := item.(string); ok {
+				cmd = append(cmd, str)
+			}
+		}
+		return cmd
+	}
+
+	return nil
+}
+
+// GetEntrypointSlice converts entrypoint to a string slice
+func (s *Service) GetEntrypointSlice() []string {
+	if s.Entrypoint == nil {
+		return nil
+	}
+
+	switch e := s.Entrypoint.(type) {
+	case string:
+		// String format: "/app/entrypoint.sh"
+		return []string{e}
+	case []interface{}:
+		// Array format: ["/app/entrypoint.sh", "arg1"]
+		var ep []string
+		for _, item := range e {
+			if str, ok := item.(string); ok {
+				ep = append(ep, str)
+			}
+		}
+		return ep
+	}
+
+	return nil
+}

--- a/pkg/compose/parser_test.go
+++ b/pkg/compose/parser_test.go
@@ -1,0 +1,408 @@
+package compose
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParse_Valid(t *testing.T) {
+	// Create a temporary compose file
+	tmpDir := t.TempDir()
+	composePath := filepath.Join(tmpDir, "docker-compose.yml")
+
+	content := `version: "3.8"
+services:
+  web:
+    image: nginx:latest
+    ports:
+      - "8080:80"
+    environment:
+      - FOO=bar
+      - BAZ=qux
+    depends_on:
+      - db
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: secret
+`
+
+	if err := os.WriteFile(composePath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Parse
+	compose, err := Parse(composePath)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	// Validate
+	if compose.Version != "3.8" {
+		t.Errorf("expected version 3.8, got %s", compose.Version)
+	}
+
+	if len(compose.Services) != 2 {
+		t.Errorf("expected 2 services, got %d", len(compose.Services))
+	}
+
+	// Check web service
+	web, ok := compose.Services["web"]
+	if !ok {
+		t.Fatal("web service not found")
+	}
+
+	if web.Image != "nginx:latest" {
+		t.Errorf("expected nginx:latest, got %s", web.Image)
+	}
+
+	if len(web.Ports) != 1 || web.Ports[0] != "8080:80" {
+		t.Errorf("unexpected ports: %v", web.Ports)
+	}
+
+	env := web.GetEnvironmentMap()
+	if env["FOO"] != "bar" || env["BAZ"] != "qux" {
+		t.Errorf("unexpected environment: %v", env)
+	}
+
+	deps := web.GetDependsOnList()
+	if len(deps) != 1 || deps[0] != "db" {
+		t.Errorf("unexpected dependencies: %v", deps)
+	}
+}
+
+func TestParse_InvalidYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	composePath := filepath.Join(tmpDir, "docker-compose.yml")
+
+	content := `version: "3.8"
+services:
+  web:
+    image nginx:latest
+    - invalid yaml
+`
+
+	if err := os.WriteFile(composePath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Parse(composePath)
+	if err == nil {
+		t.Error("expected error for invalid YAML, got nil")
+	}
+}
+
+func TestParse_MissingVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+	composePath := filepath.Join(tmpDir, "docker-compose.yml")
+
+	content := `services:
+  web:
+    image: nginx:latest
+`
+
+	if err := os.WriteFile(composePath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Parse(composePath)
+	if err == nil {
+		t.Error("expected error for missing version, got nil")
+	}
+}
+
+func TestParse_UnsupportedVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+	composePath := filepath.Join(tmpDir, "docker-compose.yml")
+
+	content := `version: "2.1"
+services:
+  web:
+    image: nginx:latest
+`
+
+	if err := os.WriteFile(composePath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Parse(composePath)
+	if err == nil {
+		t.Error("expected error for unsupported version, got nil")
+	}
+}
+
+func TestParse_NoServices(t *testing.T) {
+	tmpDir := t.TempDir()
+	composePath := filepath.Join(tmpDir, "docker-compose.yml")
+
+	content := `version: "3.8"
+services: {}
+`
+
+	if err := os.WriteFile(composePath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Parse(composePath)
+	if err == nil {
+		t.Error("expected error for no services, got nil")
+	}
+}
+
+func TestParse_NoImageOrBuild(t *testing.T) {
+	tmpDir := t.TempDir()
+	composePath := filepath.Join(tmpDir, "docker-compose.yml")
+
+	content := `version: "3.8"
+services:
+  web:
+    ports:
+      - "8080:80"
+`
+
+	if err := os.WriteFile(composePath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Parse(composePath)
+	if err == nil {
+		t.Error("expected error for missing image/build, got nil")
+	}
+}
+
+func TestGetEnvironmentMap_Array(t *testing.T) {
+	service := Service{
+		Environment: []interface{}{"FOO=bar", "BAZ=qux", "EMPTY="},
+	}
+
+	env := service.GetEnvironmentMap()
+
+	if env["FOO"] != "bar" {
+		t.Errorf("expected FOO=bar, got FOO=%s", env["FOO"])
+	}
+	if env["BAZ"] != "qux" {
+		t.Errorf("expected BAZ=qux, got BAZ=%s", env["BAZ"])
+	}
+	if env["EMPTY"] != "" {
+		t.Errorf("expected EMPTY=, got EMPTY=%s", env["EMPTY"])
+	}
+}
+
+func TestGetEnvironmentMap_Map(t *testing.T) {
+	service := Service{
+		Environment: map[string]interface{}{
+			"FOO":   "bar",
+			"BAZ":   "qux",
+			"NUM":   123,
+			"EMPTY": nil,
+		},
+	}
+
+	env := service.GetEnvironmentMap()
+
+	if env["FOO"] != "bar" {
+		t.Errorf("expected FOO=bar, got FOO=%s", env["FOO"])
+	}
+	if env["BAZ"] != "qux" {
+		t.Errorf("expected BAZ=qux, got BAZ=%s", env["BAZ"])
+	}
+	if env["NUM"] != "123" {
+		t.Errorf("expected NUM=123, got NUM=%s", env["NUM"])
+	}
+	if env["EMPTY"] != "" {
+		t.Errorf("expected EMPTY=, got EMPTY=%s", env["EMPTY"])
+	}
+}
+
+func TestGetDependsOnList_Array(t *testing.T) {
+	service := Service{
+		DependsOn: []interface{}{"db", "cache", "queue"},
+	}
+
+	deps := service.GetDependsOnList()
+
+	if len(deps) != 3 {
+		t.Fatalf("expected 3 dependencies, got %d", len(deps))
+	}
+	if deps[0] != "db" || deps[1] != "cache" || deps[2] != "queue" {
+		t.Errorf("unexpected dependencies: %v", deps)
+	}
+}
+
+func TestGetDependsOnList_Map(t *testing.T) {
+	service := Service{
+		DependsOn: map[string]interface{}{
+			"db":    map[string]interface{}{"condition": "service_healthy"},
+			"cache": map[string]interface{}{"condition": "service_started"},
+		},
+	}
+
+	deps := service.GetDependsOnList()
+
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 dependencies, got %d", len(deps))
+	}
+
+	// Note: map iteration order is not guaranteed, so just check both are present
+	depsMap := make(map[string]bool)
+	for _, d := range deps {
+		depsMap[d] = true
+	}
+
+	if !depsMap["db"] || !depsMap["cache"] {
+		t.Errorf("expected db and cache, got %v", deps)
+	}
+}
+
+func TestGetCommandSlice_String(t *testing.T) {
+	service := Service{
+		Command: "npm start",
+	}
+
+	cmd := service.GetCommandSlice()
+
+	if len(cmd) != 3 || cmd[0] != "/bin/sh" || cmd[1] != "-c" || cmd[2] != "npm start" {
+		t.Errorf("unexpected command: %v", cmd)
+	}
+}
+
+func TestGetCommandSlice_Array(t *testing.T) {
+	service := Service{
+		Command: []interface{}{"npm", "run", "start"},
+	}
+
+	cmd := service.GetCommandSlice()
+
+	if len(cmd) != 3 || cmd[0] != "npm" || cmd[1] != "run" || cmd[2] != "start" {
+		t.Errorf("unexpected command: %v", cmd)
+	}
+}
+
+func TestGetEntrypointSlice_String(t *testing.T) {
+	service := Service{
+		Entrypoint: "/app/entrypoint.sh",
+	}
+
+	ep := service.GetEntrypointSlice()
+
+	if len(ep) != 1 || ep[0] != "/app/entrypoint.sh" {
+		t.Errorf("unexpected entrypoint: %v", ep)
+	}
+}
+
+func TestGetEntrypointSlice_Array(t *testing.T) {
+	service := Service{
+		Entrypoint: []interface{}{"/app/entrypoint.sh", "arg1", "arg2"},
+	}
+
+	ep := service.GetEntrypointSlice()
+
+	if len(ep) != 3 || ep[0] != "/app/entrypoint.sh" || ep[1] != "arg1" || ep[2] != "arg2" {
+		t.Errorf("unexpected entrypoint: %v", ep)
+	}
+}
+
+func TestParse_ComplexCompose(t *testing.T) {
+	tmpDir := t.TempDir()
+	composePath := filepath.Join(tmpDir, "docker-compose.yml")
+
+	content := `version: "3.9"
+services:
+  web:
+    image: nginx:latest
+    container_name: my-web
+    ports:
+      - "8080:80"
+      - "8443:443"
+    environment:
+      NGINX_HOST: example.com
+      NGINX_PORT: 80
+    volumes:
+      - web-data:/var/www/html
+    depends_on:
+      - db
+      - cache
+    restart: always
+    networks:
+      - frontend
+      - backend
+
+  db:
+    image: postgres:15
+    environment:
+      - POSTGRES_DB=mydb
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=secret
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    networks:
+      - backend
+
+  cache:
+    image: redis:7-alpine
+    command: redis-server --appendonly yes
+    volumes:
+      - cache-data:/data
+    networks:
+      - backend
+
+networks:
+  frontend:
+  backend:
+
+volumes:
+  web-data:
+  db-data:
+  cache-data:
+`
+
+	if err := os.WriteFile(composePath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	compose, err := Parse(composePath)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	// Check structure
+	if len(compose.Services) != 3 {
+		t.Errorf("expected 3 services, got %d", len(compose.Services))
+	}
+
+	if len(compose.Networks) != 2 {
+		t.Errorf("expected 2 networks, got %d", len(compose.Networks))
+	}
+
+	if len(compose.Volumes) != 3 {
+		t.Errorf("expected 3 volumes, got %d", len(compose.Volumes))
+	}
+
+	// Check web service details
+	web := compose.Services["web"]
+	if web.ContainerName != "my-web" {
+		t.Errorf("expected container_name my-web, got %s", web.ContainerName)
+	}
+
+	if len(web.Ports) != 2 {
+		t.Errorf("expected 2 ports, got %d", len(web.Ports))
+	}
+
+	env := web.GetEnvironmentMap()
+	if env["NGINX_HOST"] != "example.com" {
+		t.Errorf("expected NGINX_HOST=example.com, got %s", env["NGINX_HOST"])
+	}
+
+	deps := web.GetDependsOnList()
+	if len(deps) != 2 {
+		t.Errorf("expected 2 dependencies, got %d", len(deps))
+	}
+
+	// Check cache service command
+	cache := compose.Services["cache"]
+	cmd := cache.GetCommandSlice()
+	if cmd[2] != "redis-server --appendonly yes" {
+		t.Errorf("unexpected command: %v", cmd)
+	}
+}

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -1,0 +1,197 @@
+package converter
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/volantvm/volant/pkg/compose"
+	"github.com/volantvm/volant/pkg/volant"
+)
+
+// ConversionError represents an error during conversion with helpful context
+type ConversionError struct {
+	Service string
+	Field   string
+	Message string
+	Help    string
+}
+
+func (e *ConversionError) Error() string {
+	msg := fmt.Sprintf("service '%s': %s", e.Service, e.Message)
+	if e.Help != "" {
+		msg += "\n   → " + e.Help
+	}
+	return msg
+}
+
+// Convert converts a Docker Compose file to a Volant stack file
+func Convert(composeFile *compose.ComposeFile, stackName string) (*volant.StackFile, error) {
+	// Derive stack name from compose file if not provided
+	if stackName == "" {
+		stackName = "default-stack"
+	}
+
+	stack := &volant.StackFile{
+		Version:  "1.0",
+		Name:     stackName,
+		Services: make(map[string]volant.StackService),
+		Volumes:  make(map[string]volant.StackVolume),
+	}
+
+	// Convert services
+	for name, svc := range composeFile.Services {
+		stackService, err := convertService(name, svc)
+		if err != nil {
+			return nil, err
+		}
+		stack.Services[name] = stackService
+	}
+
+	// Convert volumes
+	for name := range composeFile.Volumes {
+		stack.Volumes[name] = volant.StackVolume{
+			Size: "10G", // Default size, can be customized
+		}
+	}
+
+	// Set defaults and validate
+	stack.SetDefaults()
+	if err := stack.Validate(); err != nil {
+		return nil, err
+	}
+
+	return stack, nil
+}
+
+// convertService converts a Docker Compose service to a Volant service
+func convertService(name string, svc compose.Service) (volant.StackService, error) {
+	stackSvc := volant.StackService{}
+
+	// Check for unsupported 'build' directive
+	if svc.Build != nil {
+		return stackSvc, &ConversionError{
+			Service: name,
+			Field:   "build",
+			Message: "'build' directive not supported",
+			Help:    "Use Fledge to build images: fledge build -f Dockerfile",
+		}
+	}
+
+	// Image is required (validated earlier, but double-check)
+	if svc.Image == "" {
+		return stackSvc, &ConversionError{
+			Service: name,
+			Field:   "image",
+			Message: "image is required",
+			Help:    "Specify an image or use Fledge to build one",
+		}
+	}
+	stackSvc.Image = svc.Image
+
+	// Convert ports (direct copy)
+	stackSvc.Ports = svc.Ports
+
+	// Convert environment (array or map → map)
+	stackSvc.Env = svc.GetEnvironmentMap()
+
+	// Convert depends_on (array or map → array)
+	stackSvc.DependsOn = svc.GetDependsOnList()
+
+	// Convert volumes
+	volumes, err := convertVolumes(name, svc.Volumes)
+	if err != nil {
+		return stackSvc, err
+	}
+	stackSvc.Volumes = volumes
+
+	// Convert command
+	if cmd := svc.GetCommandSlice(); cmd != nil {
+		// In Volant, command goes to args
+		stackSvc.Args = cmd
+	}
+
+	// Convert entrypoint
+	if ep := svc.GetEntrypointSlice(); ep != nil {
+		stackSvc.Entrypoint = ep
+	}
+
+	// Check for unsupported deploy.replicas
+	if svc.Deploy != nil && svc.Deploy.Replicas > 1 {
+		return stackSvc, &ConversionError{
+			Service: name,
+			Field:   "deploy.replicas",
+			Message: fmt.Sprintf("deploy.replicas=%d not supported yet", svc.Deploy.Replicas),
+			Help:    "Phase 2 feature (horizontal scaling)",
+		}
+	}
+
+	return stackSvc, nil
+}
+
+// convertVolumes converts Docker Compose volume mounts to Volant volume mounts
+// Rejects bind mounts, only allows named volumes
+func convertVolumes(serviceName string, volumes []string) ([]string, error) {
+	var converted []string
+
+	for _, vol := range volumes {
+		// Parse volume string: can be "volume_name:/path" or "./local:/path" (bind mount)
+		parts := strings.SplitN(vol, ":", 2)
+		if len(parts) != 2 {
+			return nil, &ConversionError{
+				Service: serviceName,
+				Field:   "volumes",
+				Message: fmt.Sprintf("invalid volume format: %s", vol),
+				Help:    "Use format: volume_name:/container/path",
+			}
+		}
+
+		source := parts[0]
+		target := parts[1]
+
+		// Check for bind mount (starts with . or /)
+		if isBindMount(source) {
+			return nil, &ConversionError{
+				Service: serviceName,
+				Field:   "volumes",
+				Message: fmt.Sprintf("bind mount '%s' not supported", vol),
+				Help:    "Use named volumes instead: volumes: [data:/data]",
+			}
+		}
+
+		// Named volume - keep as is
+		converted = append(converted, fmt.Sprintf("%s:%s", source, target))
+	}
+
+	return converted, nil
+}
+
+// isBindMount checks if a volume source is a bind mount (local path)
+func isBindMount(source string) bool {
+	// Bind mounts start with:
+	// - . (relative path like ./data or ../config)
+	// - / (absolute path like /var/data)
+	// - ~ (home directory like ~/data)
+	return strings.HasPrefix(source, ".") ||
+		strings.HasPrefix(source, "/") ||
+		strings.HasPrefix(source, "~")
+}
+
+// DeriveStackName derives a stack name from a compose file path
+func DeriveStackName(composePath string) string {
+	// Get directory name as stack name
+	dir := filepath.Dir(composePath)
+	name := filepath.Base(dir)
+
+	// If in current directory, use "app"
+	if name == "." {
+		name = "app"
+	}
+
+	// Sanitize name (lowercase, replace spaces/special chars with -)
+	name = strings.ToLower(name)
+	name = strings.ReplaceAll(name, " ", "-")
+	name = strings.ReplaceAll(name, "_", "-")
+
+	return name
+}

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -1,0 +1,411 @@
+package converter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/volantvm/volant/pkg/compose"
+)
+
+func TestConvert_Simple(t *testing.T) {
+	composeFile := &compose.ComposeFile{
+		Version: "3.8",
+		Services: map[string]compose.Service{
+			"web": {
+				Image: "nginx:latest",
+				Ports: []string{"8080:80"},
+			},
+		},
+	}
+
+	stack, err := Convert(composeFile, "test-stack")
+	if err != nil {
+		t.Fatalf("Convert() error = %v", err)
+	}
+
+	if stack.Name != "test-stack" {
+		t.Errorf("expected name test-stack, got %s", stack.Name)
+	}
+
+	if len(stack.Services) != 1 {
+		t.Errorf("expected 1 service, got %d", len(stack.Services))
+	}
+
+	web := stack.Services["web"]
+	if web.Image != "nginx:latest" {
+		t.Errorf("expected nginx:latest, got %s", web.Image)
+	}
+
+	if len(web.Ports) != 1 || web.Ports[0] != "8080:80" {
+		t.Errorf("unexpected ports: %v", web.Ports)
+	}
+
+	// Check defaults were applied
+	if web.Memory != 512 {
+		t.Errorf("expected default memory 512, got %d", web.Memory)
+	}
+	if web.VCPUs != 1 {
+		t.Errorf("expected default vcpus 1, got %d", web.VCPUs)
+	}
+}
+
+func TestConvert_WithEnvironment(t *testing.T) {
+	composeFile := &compose.ComposeFile{
+		Version: "3.8",
+		Services: map[string]compose.Service{
+			"app": {
+				Image: "myapp:1.0",
+				Environment: []interface{}{
+					"FOO=bar",
+					"BAZ=qux",
+				},
+			},
+		},
+	}
+
+	stack, err := Convert(composeFile, "test")
+	if err != nil {
+		t.Fatalf("Convert() error = %v", err)
+	}
+
+	app := stack.Services["app"]
+	if app.Env["FOO"] != "bar" {
+		t.Errorf("expected FOO=bar, got %v", app.Env)
+	}
+	if app.Env["BAZ"] != "qux" {
+		t.Errorf("expected BAZ=qux, got %v", app.Env)
+	}
+}
+
+func TestConvert_WithDependencies(t *testing.T) {
+	composeFile := &compose.ComposeFile{
+		Version: "3.8",
+		Services: map[string]compose.Service{
+			"web": {
+				Image:     "nginx",
+				DependsOn: []interface{}{"db", "cache"},
+			},
+			"db": {
+				Image: "postgres",
+			},
+			"cache": {
+				Image: "redis",
+			},
+		},
+	}
+
+	stack, err := Convert(composeFile, "test")
+	if err != nil {
+		t.Fatalf("Convert() error = %v", err)
+	}
+
+	web := stack.Services["web"]
+	if len(web.DependsOn) != 2 {
+		t.Errorf("expected 2 dependencies, got %d", len(web.DependsOn))
+	}
+}
+
+func TestConvert_WithNamedVolumes(t *testing.T) {
+	composeFile := &compose.ComposeFile{
+		Version: "3.8",
+		Services: map[string]compose.Service{
+			"db": {
+				Image:   "postgres",
+				Volumes: []string{"db-data:/var/lib/postgresql/data"},
+			},
+		},
+		Volumes: map[string]compose.Volume{
+			"db-data": {},
+		},
+	}
+
+	stack, err := Convert(composeFile, "test")
+	if err != nil {
+		t.Fatalf("Convert() error = %v", err)
+	}
+
+	db := stack.Services["db"]
+	if len(db.Volumes) != 1 {
+		t.Errorf("expected 1 volume, got %d", len(db.Volumes))
+	}
+	if db.Volumes[0] != "db-data:/var/lib/postgresql/data" {
+		t.Errorf("unexpected volume: %s", db.Volumes[0])
+	}
+
+	// Check volume definition
+	if len(stack.Volumes) != 1 {
+		t.Errorf("expected 1 volume definition, got %d", len(stack.Volumes))
+	}
+	if _, exists := stack.Volumes["db-data"]; !exists {
+		t.Error("expected db-data volume definition")
+	}
+}
+
+func TestConvert_WithCommand(t *testing.T) {
+	composeFile := &compose.ComposeFile{
+		Version: "3.8",
+		Services: map[string]compose.Service{
+			"app": {
+				Image:   "myapp",
+				Command: []interface{}{"npm", "start"},
+			},
+		},
+	}
+
+	stack, err := Convert(composeFile, "test")
+	if err != nil {
+		t.Fatalf("Convert() error = %v", err)
+	}
+
+	app := stack.Services["app"]
+	if len(app.Args) != 2 || app.Args[0] != "npm" || app.Args[1] != "start" {
+		t.Errorf("unexpected args: %v", app.Args)
+	}
+}
+
+func TestConvert_WithEntrypoint(t *testing.T) {
+	composeFile := &compose.ComposeFile{
+		Version: "3.8",
+		Services: map[string]compose.Service{
+			"app": {
+				Image:      "myapp",
+				Entrypoint: []interface{}{"/app/entrypoint.sh", "arg1"},
+			},
+		},
+	}
+
+	stack, err := Convert(composeFile, "test")
+	if err != nil {
+		t.Fatalf("Convert() error = %v", err)
+	}
+
+	app := stack.Services["app"]
+	if len(app.Entrypoint) != 2 || app.Entrypoint[0] != "/app/entrypoint.sh" {
+		t.Errorf("unexpected entrypoint: %v", app.Entrypoint)
+	}
+}
+
+func TestConvert_ErrorOnBuild(t *testing.T) {
+	composeFile := &compose.ComposeFile{
+		Version: "3.8",
+		Services: map[string]compose.Service{
+			"app": {
+				Build: &compose.BuildConfig{
+					Context: "./app",
+				},
+				Image: "myapp:latest",
+			},
+		},
+	}
+
+	_, err := Convert(composeFile, "test")
+	if err == nil {
+		t.Fatal("expected error for build directive, got nil")
+	}
+
+	convErr, ok := err.(*ConversionError)
+	if !ok {
+		t.Fatalf("expected ConversionError, got %T", err)
+	}
+
+	if convErr.Service != "app" {
+		t.Errorf("expected service 'app', got %s", convErr.Service)
+	}
+
+	if !strings.Contains(err.Error(), "build") {
+		t.Errorf("expected error to mention 'build', got: %s", err.Error())
+	}
+
+	if !strings.Contains(err.Error(), "Fledge") {
+		t.Errorf("expected error to mention 'Fledge', got: %s", err.Error())
+	}
+}
+
+func TestConvert_ErrorOnBindMount(t *testing.T) {
+	tests := []struct {
+		name   string
+		volume string
+	}{
+		{"relative path", "./data:/data"},
+		{"absolute path", "/host/data:/data"},
+		{"home directory", "~/data:/data"},
+		{"parent directory", "../data:/data"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			composeFile := &compose.ComposeFile{
+				Version: "3.8",
+				Services: map[string]compose.Service{
+					"app": {
+						Image:   "myapp",
+						Volumes: []string{tt.volume},
+					},
+				},
+			}
+
+			_, err := Convert(composeFile, "test")
+			if err == nil {
+				t.Fatalf("expected error for bind mount %s, got nil", tt.volume)
+			}
+
+			_, ok := err.(*ConversionError)
+			if !ok {
+				t.Fatalf("expected ConversionError, got %T", err)
+			}
+
+			if !strings.Contains(err.Error(), "bind mount") {
+				t.Errorf("expected error to mention 'bind mount', got: %s", err.Error())
+			}
+		})
+	}
+}
+
+func TestConvert_ErrorOnReplicas(t *testing.T) {
+	composeFile := &compose.ComposeFile{
+		Version: "3.8",
+		Services: map[string]compose.Service{
+			"app": {
+				Image: "myapp",
+				Deploy: &compose.DeployConfig{
+					Replicas: 3,
+				},
+			},
+		},
+	}
+
+	_, err := Convert(composeFile, "test")
+	if err == nil {
+		t.Fatal("expected error for replicas > 1, got nil")
+	}
+
+	_, ok := err.(*ConversionError)
+	if !ok {
+		t.Fatalf("expected ConversionError, got %T", err)
+	}
+
+	if !strings.Contains(err.Error(), "replicas") {
+		t.Errorf("expected error to mention 'replicas', got: %s", err.Error())
+	}
+}
+
+func TestConvert_ComplexStack(t *testing.T) {
+	composeFile := &compose.ComposeFile{
+		Version: "3.8",
+		Services: map[string]compose.Service{
+			"web": {
+				Image: "nginx:latest",
+				Ports: []string{"8080:80", "8443:443"},
+				Environment: map[string]interface{}{
+					"NGINX_HOST": "example.com",
+					"NGINX_PORT": "80",
+				},
+				Volumes:   []string{"web-data:/var/www/html"},
+				DependsOn: []interface{}{"db", "cache"},
+			},
+			"db": {
+				Image: "postgres:15",
+				Environment: []interface{}{
+					"POSTGRES_DB=mydb",
+					"POSTGRES_USER=user",
+					"POSTGRES_PASSWORD=secret",
+				},
+				Volumes: []string{"db-data:/var/lib/postgresql/data"},
+			},
+			"cache": {
+				Image:   "redis:7-alpine",
+				Command: "redis-server --appendonly yes",
+			},
+		},
+		Volumes: map[string]compose.Volume{
+			"web-data": {},
+			"db-data":  {},
+		},
+	}
+
+	stack, err := Convert(composeFile, "my-stack")
+	if err != nil {
+		t.Fatalf("Convert() error = %v", err)
+	}
+
+	// Validate structure
+	if stack.Name != "my-stack" {
+		t.Errorf("expected name my-stack, got %s", stack.Name)
+	}
+
+	if len(stack.Services) != 3 {
+		t.Errorf("expected 3 services, got %d", len(stack.Services))
+	}
+
+	if len(stack.Volumes) != 2 {
+		t.Errorf("expected 2 volumes, got %d", len(stack.Volumes))
+	}
+
+	// Check web service
+	web := stack.Services["web"]
+	if len(web.Ports) != 2 {
+		t.Errorf("expected 2 ports, got %d", len(web.Ports))
+	}
+	if len(web.DependsOn) != 2 {
+		t.Errorf("expected 2 dependencies, got %d", len(web.DependsOn))
+	}
+	if web.Env["NGINX_HOST"] != "example.com" {
+		t.Errorf("expected NGINX_HOST=example.com, got %s", web.Env["NGINX_HOST"])
+	}
+
+	// Check db service
+	db := stack.Services["db"]
+	if db.Env["POSTGRES_DB"] != "mydb" {
+		t.Errorf("expected POSTGRES_DB=mydb, got %s", db.Env["POSTGRES_DB"])
+	}
+
+	// Check cache service
+	cache := stack.Services["cache"]
+	if len(cache.Args) == 0 {
+		t.Error("expected cache to have args from command")
+	}
+}
+
+func TestDeriveStackName(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		{"/home/user/myapp/docker-compose.yml", "myapp"},
+		{"/home/user/My App/docker-compose.yml", "my-app"},
+		{"./docker-compose.yml", "app"},
+		{"/home/user/project_name/docker-compose.yml", "project-name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			result := DeriveStackName(tt.path)
+			if result != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestIsBindMount(t *testing.T) {
+	tests := []struct {
+		source   string
+		expected bool
+	}{
+		{"./data", true},
+		{"../config", true},
+		{"/var/data", true},
+		{"~/documents", true},
+		{"volume-name", false},
+		{"my-data", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.source, func(t *testing.T) {
+			result := isBindMount(tt.source)
+			if result != tt.expected {
+				t.Errorf("isBindMount(%s) = %v, expected %v", tt.source, result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/converter/integration_test.go
+++ b/pkg/converter/integration_test.go
@@ -1,0 +1,344 @@
+package converter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/volantvm/volant/pkg/compose"
+	"github.com/volantvm/volant/pkg/volant"
+)
+
+// TestIntegration_WordPress tests converting a WordPress stack
+func TestIntegration_WordPress(t *testing.T) {
+	composePath := "../../testdata/wordpress/docker-compose.yml"
+	if _, err := os.Stat(composePath); os.IsNotExist(err) {
+		t.Skip("Test data not found")
+	}
+
+	// Parse
+	composeFile, err := compose.Parse(composePath)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	// Convert
+	stack, err := Convert(composeFile, "wordpress-stack")
+	if err != nil {
+		t.Fatalf("Convert() error = %v", err)
+	}
+
+	// Validate structure
+	if stack.Name != "wordpress-stack" {
+		t.Errorf("expected name wordpress-stack, got %s", stack.Name)
+	}
+
+	if len(stack.Services) != 2 {
+		t.Errorf("expected 2 services, got %d", len(stack.Services))
+	}
+
+	// Check wordpress service
+	wp, exists := stack.Services["wordpress"]
+	if !exists {
+		t.Fatal("wordpress service not found")
+	}
+
+	if wp.Image != "wordpress:latest" {
+		t.Errorf("expected wordpress:latest, got %s", wp.Image)
+	}
+
+	if len(wp.Ports) != 1 {
+		t.Errorf("expected 1 port, got %d", len(wp.Ports))
+	}
+
+	if len(wp.DependsOn) != 1 || wp.DependsOn[0] != "db" {
+		t.Errorf("expected depends_on: [db], got %v", wp.DependsOn)
+	}
+
+	if wp.Env["WORDPRESS_DB_HOST"] != "db" {
+		t.Errorf("expected WORDPRESS_DB_HOST=db, got %s", wp.Env["WORDPRESS_DB_HOST"])
+	}
+
+	// Check db service
+	db, exists := stack.Services["db"]
+	if !exists {
+		t.Fatal("db service not found")
+	}
+
+	if db.Image != "mysql:8.0" {
+		t.Errorf("expected mysql:8.0, got %s", db.Image)
+	}
+
+	if db.Env["MYSQL_DATABASE"] != "wordpress" {
+		t.Errorf("expected MYSQL_DATABASE=wordpress, got %s", db.Env["MYSQL_DATABASE"])
+	}
+
+	// Check volumes
+	if len(stack.Volumes) != 2 {
+		t.Errorf("expected 2 volumes, got %d", len(stack.Volumes))
+	}
+}
+
+// TestIntegration_NodeJsMongo tests converting a Node.js + MongoDB stack
+func TestIntegration_NodeJsMongo(t *testing.T) {
+	composePath := "../../testdata/nodejs-mongo/docker-compose.yml"
+	if _, err := os.Stat(composePath); os.IsNotExist(err) {
+		t.Skip("Test data not found")
+	}
+
+	composeFile, err := compose.Parse(composePath)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	stack, err := Convert(composeFile, "nodejs-stack")
+	if err != nil {
+		t.Fatalf("Convert() error = %v", err)
+	}
+
+	// Check app service
+	app, exists := stack.Services["app"]
+	if !exists {
+		t.Fatal("app service not found")
+	}
+
+	if app.Image != "node:18-alpine" {
+		t.Errorf("expected node:18-alpine, got %s", app.Image)
+	}
+
+	// Check command was converted to args
+	if len(app.Args) != 2 || app.Args[0] != "node" || app.Args[1] != "server.js" {
+		t.Errorf("expected args: [node server.js], got %v", app.Args)
+	}
+
+	// Check environment
+	if app.Env["NODE_ENV"] != "production" {
+		t.Errorf("expected NODE_ENV=production, got %s", app.Env["NODE_ENV"])
+	}
+
+	// Check mongo service
+	mongo, exists := stack.Services["mongo"]
+	if !exists {
+		t.Fatal("mongo service not found")
+	}
+
+	if mongo.Env["MONGO_INITDB_ROOT_USERNAME"] != "admin" {
+		t.Errorf("expected MONGO_INITDB_ROOT_USERNAME=admin, got %s", mongo.Env["MONGO_INITDB_ROOT_USERNAME"])
+	}
+}
+
+// TestIntegration_NginxProxy tests converting an Nginx reverse proxy setup
+func TestIntegration_NginxProxy(t *testing.T) {
+	composePath := "../../testdata/nginx-proxy/docker-compose.yml"
+	if _, err := os.Stat(composePath); os.IsNotExist(err) {
+		t.Skip("Test data not found")
+	}
+
+	composeFile, err := compose.Parse(composePath)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	stack, err := Convert(composeFile, "nginx-stack")
+	if err != nil {
+		t.Fatalf("Convert() error = %v", err)
+	}
+
+	if len(stack.Services) != 3 {
+		t.Errorf("expected 3 services, got %d", len(stack.Services))
+	}
+
+	// Check nginx dependencies
+	nginx, exists := stack.Services["nginx"]
+	if !exists {
+		t.Fatal("nginx service not found")
+	}
+
+	if len(nginx.DependsOn) != 2 {
+		t.Errorf("expected 2 dependencies, got %d", len(nginx.DependsOn))
+	}
+
+	depsMap := make(map[string]bool)
+	for _, dep := range nginx.DependsOn {
+		depsMap[dep] = true
+	}
+
+	if !depsMap["backend1"] || !depsMap["backend2"] {
+		t.Errorf("expected dependencies on backend1 and backend2, got %v", nginx.DependsOn)
+	}
+}
+
+// TestIntegration_ErrorOnBuild tests that build directive is rejected
+func TestIntegration_ErrorOnBuild(t *testing.T) {
+	composePath := "../../testdata/error-build/docker-compose.yml"
+	if _, err := os.Stat(composePath); os.IsNotExist(err) {
+		t.Skip("Test data not found")
+	}
+
+	composeFile, err := compose.Parse(composePath)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	_, err = Convert(composeFile, "test")
+	if err == nil {
+		t.Fatal("expected error for build directive, got nil")
+	}
+
+	convErr, ok := err.(*ConversionError)
+	if !ok {
+		t.Fatalf("expected ConversionError, got %T", err)
+	}
+
+	if convErr.Service != "app" {
+		t.Errorf("expected service 'app', got %s", convErr.Service)
+	}
+
+	if convErr.Field != "build" {
+		t.Errorf("expected field 'build', got %s", convErr.Field)
+	}
+}
+
+// TestIntegration_ErrorOnBindMount tests that bind mounts are rejected
+func TestIntegration_ErrorOnBindMount(t *testing.T) {
+	composePath := "../../testdata/error-bindmount/docker-compose.yml"
+	if _, err := os.Stat(composePath); os.IsNotExist(err) {
+		t.Skip("Test data not found")
+	}
+
+	composeFile, err := compose.Parse(composePath)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	_, err = Convert(composeFile, "test")
+	if err == nil {
+		t.Fatal("expected error for bind mount, got nil")
+	}
+
+	convErr, ok := err.(*ConversionError)
+	if !ok {
+		t.Fatalf("expected ConversionError, got %T", err)
+	}
+
+	if convErr.Service != "app" {
+		t.Errorf("expected service 'app', got %s", convErr.Service)
+	}
+
+	if convErr.Field != "volumes" {
+		t.Errorf("expected field 'volumes', got %s", convErr.Field)
+	}
+}
+
+// TestIntegration_RoundTrip tests that we can convert and write YAML correctly
+func TestIntegration_RoundTrip(t *testing.T) {
+	composePath := "../../testdata/wordpress/docker-compose.yml"
+	if _, err := os.Stat(composePath); os.IsNotExist(err) {
+		t.Skip("Test data not found")
+	}
+
+	// Parse compose
+	composeFile, err := compose.Parse(composePath)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	// Convert
+	stack, err := Convert(composeFile, "test-stack")
+	if err != nil {
+		t.Fatalf("Convert() error = %v", err)
+	}
+
+	// Write to temp file
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "volant.yaml")
+
+	if err := volant.WriteYAML(stack, outputPath); err != nil {
+		t.Fatalf("WriteYAML() error = %v", err)
+	}
+
+	// Read back
+	parsed, err := volant.Parse(outputPath)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	// Validate
+	if parsed.Name != "test-stack" {
+		t.Errorf("expected name test-stack, got %s", parsed.Name)
+	}
+
+	if len(parsed.Services) != len(stack.Services) {
+		t.Errorf("expected %d services, got %d", len(stack.Services), len(parsed.Services))
+	}
+
+	// Check service details are preserved
+	for name, orig := range stack.Services {
+		parsed, exists := parsed.Services[name]
+		if !exists {
+			t.Errorf("service %s missing after round-trip", name)
+			continue
+		}
+
+		if parsed.Image != orig.Image {
+			t.Errorf("service %s: expected image %s, got %s", name, orig.Image, parsed.Image)
+		}
+	}
+}
+
+// TestIntegration_AllExamples tests all example files can be parsed and converted
+func TestIntegration_AllExamples(t *testing.T) {
+	testdataDir := "../../testdata"
+	entries, err := os.ReadDir(testdataDir)
+	if err != nil {
+		t.Skip("Testdata directory not found")
+	}
+
+	successCount := 0
+	errorCount := 0
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		// Skip error examples (they're supposed to fail)
+		if filepath.HasPrefix(entry.Name(), "error-") {
+			continue
+		}
+
+		composePath := filepath.Join(testdataDir, entry.Name(), "docker-compose.yml")
+		if _, err := os.Stat(composePath); os.IsNotExist(err) {
+			continue
+		}
+
+		t.Run(entry.Name(), func(t *testing.T) {
+			composeFile, err := compose.Parse(composePath)
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+
+			stack, err := Convert(composeFile, entry.Name())
+			if err != nil {
+				t.Fatalf("Convert() error = %v", err)
+			}
+
+			// Basic validation
+			if err := stack.Validate(); err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+
+			if len(stack.Services) == 0 {
+				t.Error("expected at least one service")
+			}
+
+			successCount++
+		})
+	}
+
+	if successCount == 0 {
+		t.Skip("No test examples found")
+	}
+
+	t.Logf("Successfully converted %d examples, %d errors", successCount, errorCount)
+}

--- a/pkg/volant/stack.go
+++ b/pkg/volant/stack.go
@@ -1,0 +1,173 @@
+package volant
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// StackFile represents a volant.yaml stack definition
+type StackFile struct {
+	Version  string                   `yaml:"version"`
+	Name     string                   `yaml:"name"`
+	Services map[string]StackService  `yaml:"services"`
+	Networks map[string]StackNetwork  `yaml:"networks,omitempty"`
+	Volumes  map[string]StackVolume   `yaml:"volumes,omitempty"`
+}
+
+// StackService represents a service in a Volant stack
+// Each service runs in its own microVM
+type StackService struct {
+	Image      string            `yaml:"image"`
+	Memory     int               `yaml:"memory,omitempty"`      // Memory in MB (default: 512)
+	VCPUs      int               `yaml:"vcpus,omitempty"`       // CPU count (default: 1)
+	Ports      []string          `yaml:"ports,omitempty"`       // Port mappings "host:guest"
+	Env        map[string]string `yaml:"environment,omitempty"` // Environment variables
+	Volumes    []string          `yaml:"volumes,omitempty"`     // Volume mounts "vol_name:/path"
+	DependsOn  []string          `yaml:"depends_on,omitempty"`  // Service dependencies
+	Entrypoint []string          `yaml:"entrypoint,omitempty"`  // Override entrypoint
+	Args       []string          `yaml:"args,omitempty"`        // Override args/command
+}
+
+// StackNetwork represents a network definition
+// Currently Volant uses a single default subnet (192.168.127.0/24)
+type StackNetwork struct {
+	Subnet  string `yaml:"subnet,omitempty"`
+	Gateway string `yaml:"gateway,omitempty"`
+}
+
+// StackVolume represents a persistent volume definition
+type StackVolume struct {
+	Size   string `yaml:"size,omitempty"`   // Size (e.g., "1G", "100M")
+	Driver string `yaml:"driver,omitempty"` // Driver type (default: local)
+}
+
+// Parse reads and parses a volant.yaml file
+func Parse(path string) (*StackFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %s: %w", path, err)
+	}
+
+	var stack StackFile
+	if err := yaml.Unmarshal(data, &stack); err != nil {
+		return nil, fmt.Errorf("failed to parse YAML: %w", err)
+	}
+
+	if err := stack.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &stack, nil
+}
+
+// WriteYAML writes a StackFile to a YAML file
+func WriteYAML(stack *StackFile, path string) error {
+	// Set defaults
+	if stack.Version == "" {
+		stack.Version = "1.0"
+	}
+
+	// Validate before writing
+	if err := stack.Validate(); err != nil {
+		return err
+	}
+
+	// Marshal to YAML with indentation
+	data, err := yaml.Marshal(stack)
+	if err != nil {
+		return fmt.Errorf("failed to marshal YAML: %w", err)
+	}
+
+	// Write to file
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write file %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// Validate checks if the stack file is valid
+func (s *StackFile) Validate() error {
+	if s.Version == "" {
+		return fmt.Errorf("version field is required")
+	}
+
+	if s.Version != "1.0" {
+		return fmt.Errorf("unsupported version: %s (only version 1.0 is supported)", s.Version)
+	}
+
+	if s.Name == "" {
+		return fmt.Errorf("name field is required")
+	}
+
+	if len(s.Services) == 0 {
+		return fmt.Errorf("at least one service is required")
+	}
+
+	// Validate each service
+	for name, service := range s.Services {
+		if err := service.Validate(name); err != nil {
+			return err
+		}
+	}
+
+	// Validate dependencies reference existing services
+	for name, service := range s.Services {
+		for _, dep := range service.DependsOn {
+			if _, exists := s.Services[dep]; !exists {
+				return fmt.Errorf("service '%s': depends_on references non-existent service '%s'", name, dep)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Validate checks if a service is valid
+func (s *StackService) Validate(name string) error {
+	if s.Image == "" {
+		return fmt.Errorf("service '%s': image field is required", name)
+	}
+
+	// Validate memory (if specified)
+	if s.Memory < 0 {
+		return fmt.Errorf("service '%s': memory must be positive", name)
+	}
+
+	// Validate vcpus (if specified)
+	if s.VCPUs < 0 {
+		return fmt.Errorf("service '%s': vcpus must be positive", name)
+	}
+
+	return nil
+}
+
+// SetDefaults applies default values to the stack
+func (s *StackFile) SetDefaults() {
+	if s.Version == "" {
+		s.Version = "1.0"
+	}
+
+	for name, service := range s.Services {
+		if service.Memory == 0 {
+			service.Memory = 512 // Default 512MB
+		}
+		if service.VCPUs == 0 {
+			service.VCPUs = 1 // Default 1 vCPU
+		}
+		s.Services[name] = service
+	}
+
+	// Set default network if not specified
+	if s.Networks == nil {
+		s.Networks = make(map[string]StackNetwork)
+	}
+	if _, exists := s.Networks["default"]; !exists {
+		s.Networks["default"] = StackNetwork{
+			Subnet:  "192.168.127.0/24",
+			Gateway: "192.168.127.1",
+		}
+	}
+}

--- a/pkg/volant/stack_test.go
+++ b/pkg/volant/stack_test.go
@@ -1,0 +1,342 @@
+package volant
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParse_ValidStack(t *testing.T) {
+	tmpDir := t.TempDir()
+	stackPath := filepath.Join(tmpDir, "volant.yaml")
+
+	content := `version: "1.0"
+name: "test-stack"
+services:
+  web:
+    image: nginx:latest
+    memory: 512
+    vcpus: 1
+    ports:
+      - "8080:80"
+    environment:
+      FOO: bar
+    depends_on:
+      - db
+  db:
+    image: postgres:15
+    memory: 1024
+    vcpus: 2
+    environment:
+      POSTGRES_PASSWORD: secret
+volumes:
+  db-data:
+    size: "10G"
+`
+
+	if err := os.WriteFile(stackPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	stack, err := Parse(stackPath)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	if stack.Version != "1.0" {
+		t.Errorf("expected version 1.0, got %s", stack.Version)
+	}
+
+	if stack.Name != "test-stack" {
+		t.Errorf("expected name test-stack, got %s", stack.Name)
+	}
+
+	if len(stack.Services) != 2 {
+		t.Errorf("expected 2 services, got %d", len(stack.Services))
+	}
+
+	// Check web service
+	web := stack.Services["web"]
+	if web.Image != "nginx:latest" {
+		t.Errorf("expected nginx:latest, got %s", web.Image)
+	}
+	if web.Memory != 512 {
+		t.Errorf("expected memory 512, got %d", web.Memory)
+	}
+	if web.VCPUs != 1 {
+		t.Errorf("expected vcpus 1, got %d", web.VCPUs)
+	}
+	if len(web.Ports) != 1 || web.Ports[0] != "8080:80" {
+		t.Errorf("unexpected ports: %v", web.Ports)
+	}
+	if web.Env["FOO"] != "bar" {
+		t.Errorf("expected FOO=bar, got %v", web.Env)
+	}
+	if len(web.DependsOn) != 1 || web.DependsOn[0] != "db" {
+		t.Errorf("unexpected depends_on: %v", web.DependsOn)
+	}
+}
+
+func TestWriteYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	stackPath := filepath.Join(tmpDir, "volant.yaml")
+
+	stack := &StackFile{
+		Version: "1.0",
+		Name:    "test-stack",
+		Services: map[string]StackService{
+			"web": {
+				Image:  "nginx:latest",
+				Memory: 512,
+				VCPUs:  1,
+				Ports:  []string{"8080:80"},
+				Env: map[string]string{
+					"FOO": "bar",
+				},
+			},
+		},
+	}
+
+	if err := WriteYAML(stack, stackPath); err != nil {
+		t.Fatalf("WriteYAML() error = %v", err)
+	}
+
+	// Read back and verify
+	parsed, err := Parse(stackPath)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	if parsed.Name != stack.Name {
+		t.Errorf("expected name %s, got %s", stack.Name, parsed.Name)
+	}
+
+	if len(parsed.Services) != 1 {
+		t.Errorf("expected 1 service, got %d", len(parsed.Services))
+	}
+
+	web := parsed.Services["web"]
+	if web.Image != "nginx:latest" {
+		t.Errorf("expected nginx:latest, got %s", web.Image)
+	}
+}
+
+func TestValidate_MissingVersion(t *testing.T) {
+	stack := &StackFile{
+		Name: "test",
+		Services: map[string]StackService{
+			"web": {Image: "nginx"},
+		},
+	}
+
+	if err := stack.Validate(); err == nil {
+		t.Error("expected error for missing version, got nil")
+	}
+}
+
+func TestValidate_UnsupportedVersion(t *testing.T) {
+	stack := &StackFile{
+		Version: "2.0",
+		Name:    "test",
+		Services: map[string]StackService{
+			"web": {Image: "nginx"},
+		},
+	}
+
+	if err := stack.Validate(); err == nil {
+		t.Error("expected error for unsupported version, got nil")
+	}
+}
+
+func TestValidate_MissingName(t *testing.T) {
+	stack := &StackFile{
+		Version: "1.0",
+		Services: map[string]StackService{
+			"web": {Image: "nginx"},
+		},
+	}
+
+	if err := stack.Validate(); err == nil {
+		t.Error("expected error for missing name, got nil")
+	}
+}
+
+func TestValidate_NoServices(t *testing.T) {
+	stack := &StackFile{
+		Version:  "1.0",
+		Name:     "test",
+		Services: map[string]StackService{},
+	}
+
+	if err := stack.Validate(); err == nil {
+		t.Error("expected error for no services, got nil")
+	}
+}
+
+func TestValidate_MissingImage(t *testing.T) {
+	stack := &StackFile{
+		Version: "1.0",
+		Name:    "test",
+		Services: map[string]StackService{
+			"web": {Memory: 512},
+		},
+	}
+
+	if err := stack.Validate(); err == nil {
+		t.Error("expected error for missing image, got nil")
+	}
+}
+
+func TestValidate_InvalidDependency(t *testing.T) {
+	stack := &StackFile{
+		Version: "1.0",
+		Name:    "test",
+		Services: map[string]StackService{
+			"web": {
+				Image:     "nginx",
+				DependsOn: []string{"nonexistent"},
+			},
+		},
+	}
+
+	if err := stack.Validate(); err == nil {
+		t.Error("expected error for invalid dependency, got nil")
+	}
+}
+
+func TestValidate_NegativeMemory(t *testing.T) {
+	stack := &StackFile{
+		Version: "1.0",
+		Name:    "test",
+		Services: map[string]StackService{
+			"web": {
+				Image:  "nginx",
+				Memory: -1,
+			},
+		},
+	}
+
+	if err := stack.Validate(); err == nil {
+		t.Error("expected error for negative memory, got nil")
+	}
+}
+
+func TestValidate_NegativeVCPUs(t *testing.T) {
+	stack := &StackFile{
+		Version: "1.0",
+		Name:    "test",
+		Services: map[string]StackService{
+			"web": {
+				Image: "nginx",
+				VCPUs: -1,
+			},
+		},
+	}
+
+	if err := stack.Validate(); err == nil {
+		t.Error("expected error for negative vcpus, got nil")
+	}
+}
+
+func TestSetDefaults(t *testing.T) {
+	stack := &StackFile{
+		Version: "1.0",
+		Name:    "test",
+		Services: map[string]StackService{
+			"web": {
+				Image: "nginx",
+				// No memory or vcpus specified
+			},
+		},
+	}
+
+	stack.SetDefaults()
+
+	web := stack.Services["web"]
+	if web.Memory != 512 {
+		t.Errorf("expected default memory 512, got %d", web.Memory)
+	}
+	if web.VCPUs != 1 {
+		t.Errorf("expected default vcpus 1, got %d", web.VCPUs)
+	}
+
+	// Check default network
+	if len(stack.Networks) == 0 {
+		t.Error("expected default network to be created")
+	}
+	defaultNet, exists := stack.Networks["default"]
+	if !exists {
+		t.Error("expected default network to exist")
+	}
+	if defaultNet.Subnet != "192.168.127.0/24" {
+		t.Errorf("expected default subnet 192.168.127.0/24, got %s", defaultNet.Subnet)
+	}
+}
+
+func TestComplexStack(t *testing.T) {
+	stack := &StackFile{
+		Version: "1.0",
+		Name:    "wordpress-stack",
+		Services: map[string]StackService{
+			"web": {
+				Image:  "wordpress:latest",
+				Memory: 512,
+				VCPUs:  1,
+				Ports:  []string{"8080:80"},
+				Env: map[string]string{
+					"WORDPRESS_DB_HOST":     "db.svc.volant",
+					"WORDPRESS_DB_USER":     "wordpress",
+					"WORDPRESS_DB_PASSWORD": "secret",
+					"WORDPRESS_DB_NAME":     "wordpress",
+				},
+				Volumes:   []string{"wp-data:/var/www/html"},
+				DependsOn: []string{"db"},
+			},
+			"db": {
+				Image:  "mysql:8",
+				Memory: 1024,
+				VCPUs:  2,
+				Env: map[string]string{
+					"MYSQL_ROOT_PASSWORD": "rootsecret",
+					"MYSQL_DATABASE":      "wordpress",
+					"MYSQL_USER":          "wordpress",
+					"MYSQL_PASSWORD":      "secret",
+				},
+				Volumes: []string{"db-data:/var/lib/mysql"},
+			},
+		},
+		Volumes: map[string]StackVolume{
+			"wp-data": {Size: "1G"},
+			"db-data": {Size: "10G"},
+		},
+	}
+
+	if err := stack.Validate(); err != nil {
+		t.Errorf("Validate() error = %v", err)
+	}
+
+	// Write and read back
+	tmpDir := t.TempDir()
+	stackPath := filepath.Join(tmpDir, "wordpress.yaml")
+
+	if err := WriteYAML(stack, stackPath); err != nil {
+		t.Fatalf("WriteYAML() error = %v", err)
+	}
+
+	parsed, err := Parse(stackPath)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	if parsed.Name != "wordpress-stack" {
+		t.Errorf("expected name wordpress-stack, got %s", parsed.Name)
+	}
+
+	if len(parsed.Services) != 2 {
+		t.Errorf("expected 2 services, got %d", len(parsed.Services))
+	}
+
+	if len(parsed.Volumes) != 2 {
+		t.Errorf("expected 2 volumes, got %d", len(parsed.Volumes))
+	}
+}

--- a/testdata/error-bindmount/docker-compose.yml
+++ b/testdata/error-bindmount/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.8"
+
+services:
+  app:
+    image: nginx:latest
+    volumes:
+      - ./html:/usr/share/nginx/html
+    ports:
+      - "8080:80"

--- a/testdata/error-build/docker-compose.yml
+++ b/testdata/error-build/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+
+services:
+  app:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    image: myapp:latest
+    ports:
+      - "8080:80"

--- a/testdata/nginx-proxy/docker-compose.yml
+++ b/testdata/nginx-proxy/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.9"
+
+services:
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    depends_on:
+      - backend1
+      - backend2
+
+  backend1:
+    image: myapp:latest
+    ports:
+      - "8001:8000"
+    environment:
+      SERVICE_NAME: backend1
+
+  backend2:
+    image: myapp:latest
+    ports:
+      - "8002:8000"
+    environment:
+      SERVICE_NAME: backend2

--- a/testdata/nodejs-mongo/docker-compose.yml
+++ b/testdata/nodejs-mongo/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.8"
+
+services:
+  app:
+    image: node:18-alpine
+    ports:
+      - "3000:3000"
+    environment:
+      NODE_ENV: production
+      MONGO_URL: mongodb://mongo:27017/myapp
+    depends_on:
+      - mongo
+    command: ["node", "server.js"]
+
+  mongo:
+    image: mongo:7
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=admin
+      - MONGO_INITDB_ROOT_PASSWORD=secret
+    volumes:
+      - mongo-data:/data/db
+
+volumes:
+  mongo-data:

--- a/testdata/wordpress/docker-compose.yml
+++ b/testdata/wordpress/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.8"
+
+services:
+  wordpress:
+    image: wordpress:latest
+    ports:
+      - "8080:80"
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: secret
+      WORDPRESS_DB_NAME: wordpress
+    depends_on:
+      - db
+    volumes:
+      - wordpress-data:/var/www/html
+
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: secret
+      MYSQL_ROOT_PASSWORD: rootsecret
+    volumes:
+      - db-data:/var/lib/mysql
+
+volumes:
+  wordpress-data:
+  db-data:

--- a/testdata/wordpress/volant.yaml
+++ b/testdata/wordpress/volant.yaml
@@ -1,0 +1,38 @@
+version: "1.0"
+name: app
+services:
+    db:
+        image: mysql:8.0
+        memory: 512
+        vcpus: 1
+        environment:
+            MYSQL_DATABASE: wordpress
+            MYSQL_PASSWORD: secret
+            MYSQL_ROOT_PASSWORD: rootsecret
+            MYSQL_USER: wordpress
+        volumes:
+            - db-data:/var/lib/mysql
+    wordpress:
+        image: wordpress:latest
+        memory: 512
+        vcpus: 1
+        ports:
+            - 8080:80
+        environment:
+            WORDPRESS_DB_HOST: db
+            WORDPRESS_DB_NAME: wordpress
+            WORDPRESS_DB_PASSWORD: secret
+            WORDPRESS_DB_USER: wordpress
+        volumes:
+            - wordpress-data:/var/www/html
+        depends_on:
+            - db
+networks:
+    default:
+        subnet: 192.168.127.0/24
+        gateway: 192.168.127.1
+volumes:
+    db-data:
+        size: 10G
+    wordpress-data:
+        size: 10G


### PR DESCRIPTION
## Summary

This PR introduces `volant-compose`, a new CLI tool that converts Docker Compose files to Volant stack definitions, enabling seamless migration from Docker Compose to Volant's microVM orchestration platform.

## Features

### Convert Command
```bash
volant-compose convert -f docker-compose.yml -o volant.yaml
```
- Parses Docker Compose v3.x files
- Generates valid Volant stack YAML
- Handles environment variables (array and map formats)
- Converts service dependencies
- Maps port configurations
- Processes volume definitions

### Validate Command
```bash
volant-compose validate -f docker-compose.yml
```
- Checks if a Docker Compose file can be successfully converted
- Reports unsupported features with helpful migration guidance

## Architecture

The tool consists of three core packages:

1. **pkg/compose** - Docker Compose YAML parser
   - Supports v3.x specification
   - Handles all common service configurations
   - Flexible type handling (array/map formats)

2. **pkg/volant** - Volant stack YAML schema
   - Stack file structure with VM-specific fields (memory, vcpus)
   - Validation with dependency checking
   - Default value handling

3. **pkg/converter** - Conversion logic
   - Handles impedance mismatches between containers and VMs
   - Provides clear error messages for unsupported features
   - Derives stack names from file paths

## Supported Features

✅ Services (image, ports, environment, volumes, depends_on)  
✅ Named volumes  
✅ Port mappings  
✅ Environment variables (both array and map syntax)  
✅ Command and entrypoint overrides  

## Unsupported Features (with helpful errors)

❌ Build contexts → "Use Fledge to build images: fledge build -f Dockerfile"  
❌ Bind mounts → "Use named volumes instead: volumes: [data:/data]"  
❌ deploy.replicas → "Phase 2 feature (horizontal scaling)"  

## Testing

- **40+ unit tests** across all packages (100% pass rate)
- **7 integration tests** with real-world examples:
  - WordPress + MySQL
  - Node.js + MongoDB  
  - Nginx reverse proxy
  - Error handling for unsupported features
- **Test coverage**: 80%+ on core packages

## Examples

### WordPress Stack Conversion

Input `docker-compose.yml`:
```yaml
version: "3.8"
services:
  wordpress:
    image: wordpress:latest
    ports:
      - "8080:80"
    environment:
      WORDPRESS_DB_HOST: db
    depends_on:
      - db
  db:
    image: mysql:8.0
    environment:
      MYSQL_DATABASE: wordpress
```

Output `volant.yaml`:
```yaml
version: "1.0"
name: wordpress-stack
services:
  wordpress:
    image: wordpress:latest
    memory: 512
    vcpus: 1
    ports:
      - 8080:80
    environment:
      WORDPRESS_DB_HOST: db
    depends_on:
      - db
  db:
    image: mysql:8.0
    memory: 512
    vcpus: 1
    environment:
      MYSQL_DATABASE: wordpress
```

## Documentation

Complete migration guide added at `docs/3_guides/6_docker-compose-migration.md` including:
- Installation instructions
- Quick start guide
- Supported/unsupported features reference
- Migration guide with step-by-step instructions
- Troubleshooting section
- CLI reference
- Multiple real-world examples

## Build

```bash
make build-compose
# Binary: bin/volant-compose
```

## Files Changed

- `cmd/volant-compose/` - CLI implementation (2 files)
- `pkg/compose/` - Docker Compose parser (2 files)
- `pkg/volant/` - Volant stack schema (2 files)
- `pkg/converter/` - Conversion logic (3 files)
- `testdata/` - Integration test examples (6 files)
- `docs/3_guides/6_docker-compose-migration.md` - Complete documentation
- `Makefile` - Build target for volant-compose
- `.gitignore` - Exclude development files

Total: 18 files, 3134+ insertions

## Design Decisions

1. **Named Volumes Only**: Bind mounts are rejected as they violate VM isolation principles
2. **Single Subnet**: Volant uses a default subnet (192.168.127.0/24); custom networks are simplified
3. **VM Resource Allocation**: Default 512MB memory, 1 vCPU per service (customizable in output)
4. **No Build Support**: Image building is delegated to Fledge to maintain separation of concerns
5. **Helpful Error Messages**: Every unsupported feature includes migration guidance

## Future Work

This implementation provides the foundation for:
- Stack deployment integration (Phase 2)
- `volant-compose up/down` commands
- Resource hints from image metadata
- Multi-network support when available

## Testing Instructions

```bash
# Run all tests
go test ./pkg/compose/... ./pkg/volant/... ./pkg/converter/...

# Run integration tests
go test github.com/volantvm/volant/pkg/converter -run Integration

# Test CLI
make build-compose
./bin/volant-compose convert -f testdata/wordpress/docker-compose.yml
./bin/volant-compose validate -f testdata/nodejs-mongo/docker-compose.yml
```